### PR TITLE
Move typescript from peerDependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,7 @@
   "devDependencies": {
     "@types/bun": "latest",
     "ts-node": "^10.9.2",
-    "tsup": "^8.0.2"
-  },
-  "peerDependencies": {
+    "tsup": "^8.0.2",
     "typescript": "^5.0.0"
   }
 }


### PR DESCRIPTION
Putting TypeScript in peer makes it such that consumers of the package will also install TypeScript; was debugging why my `npm prune`d package size was so large and tracked it down to a typescript directory in this `metaphone3` install.